### PR TITLE
add retry in API Service code  and test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,14 @@ dependencies {
 	// testcontainers
 	testImplementation 'org.testcontainers:spock:1.17.1'
 	testImplementation 'org.testcontainers:mariadb:1.17.1'
+
+
+	// spring retry
+	implementation 'org.springframework.retry:spring-retry'
+
+	// mockWebServer
+	testImplementation('com.squareup.okhttp3:okhttp:4.10.0')
+	testImplementation('com.squareup.okhttp3:mockwebserver:4.10.0')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/naviproject/config/RetryConfig.java
+++ b/src/main/java/com/example/naviproject/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.example.naviproject.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+}


### PR DESCRIPTION
일시적인 네트워크 오류로 인해 API 서비스 에러를 대비해 Spring Retry 라이브러리 설치 및 구현
오류시에 3번까지 다시 호출 및 전부 에러 발생시 에러 로그를 남깁니다.