### PR TITLE
카카오 카테고리 검색 API 적용

### DIFF
--- a/src/main/java/com/example/naviproject/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/naviproject/api/dto/DocumentDto.java
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 @Builder
 public class DocumentDto {
 
+    @JsonProperty("place_name")
+    private String placeName;
+
     @JsonProperty("address_name")
     private String addressName;
 
@@ -21,4 +24,6 @@ public class DocumentDto {
     @JsonProperty("x")
     private double longitude;
 
+    @JsonProperty("distance")
+    private double distance;
 }

--- a/src/main/java/com/example/naviproject/api/service/KakaoCategorySearchService.java
+++ b/src/main/java/com/example/naviproject/api/service/KakaoCategorySearchService.java
@@ -1,0 +1,38 @@
+package com.example.naviproject.api.service;
+
+import com.example.naviproject.api.dto.KakaoApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoCategorySearchService {
+
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+    private final RestTemplate restTemplate;
+
+    private static final String PHARMACY_CATEGORY ="PM9";
+
+    @Value("${KAKAO_REST_API_KEY}")
+    private String kakaoRestApiKey;
+
+    public KakaoApiResponseDto requestPharmacyCategorySearch(double latitude, double longitude, double radius) {
+
+        URI uri = kakaoUriBuilderService.buildUriBySearchCategory(latitude, longitude, radius, PHARMACY_CATEGORY);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+}

--- a/src/main/java/com/example/naviproject/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/com/example/naviproject/api/service/KakaoUriBuilderService.java
@@ -12,6 +12,8 @@ public class KakaoUriBuilderService {
 
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
 
+    private static final String KAKAO_LOCAL_CATEGORY_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/keyword.json";
+
     public URI buildUriByAddressSearch(String address) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
         uriBuilder.queryParam("query", address);
@@ -21,6 +23,25 @@ public class KakaoUriBuilderService {
 
 
         return uri;
+    }
+
+    public URI buildUriBySearchCategory(double latitude, double longitude, double radius, String category) {
+
+        double meterRadius = radius * 1000;
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_CATEGORY_SEARCH_URL);
+        uriBuilder.queryParam("category_group_code", category);
+        uriBuilder.queryParam("x", longitude);
+        uriBuilder.queryParam("y", latitude);
+        uriBuilder.queryParam("radius", meterRadius);
+        uriBuilder.queryParam("sort","distance");
+
+        URI uri = uriBuilder.build().encode().toUri();
+
+        log.info("[KakaoAddressSearchService buildUriByCategorySearch] uri: {} ", uri);
+
+        return uri;
+
     }
 
 }

--- a/src/main/java/com/example/naviproject/direction/DirectionRepository.java
+++ b/src/main/java/com/example/naviproject/direction/DirectionRepository.java
@@ -1,0 +1,9 @@
+package com.example.naviproject.direction;
+
+
+import com.example.naviproject.direction.entity.Direction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DirectionRepository extends JpaRepository<Direction, Long> {
+
+}

--- a/src/main/java/com/example/naviproject/direction/service/DirectionService.java
+++ b/src/main/java/com/example/naviproject/direction/service/DirectionService.java
@@ -1,14 +1,17 @@
 package com.example.naviproject.direction.service;
 
 import com.example.naviproject.api.dto.DocumentDto;
+import com.example.naviproject.api.service.KakaoCategorySearchService;
+import com.example.naviproject.direction.DirectionRepository;
 import com.example.naviproject.direction.entity.Direction;
 import com.example.naviproject.pharmacy.dto.PharmacyDto;
 import com.example.naviproject.pharmacy.service.PharmacySearchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
-import javax.transaction.Transactional;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -22,9 +25,21 @@ import java.util.stream.Collectors;
 public class DirectionService {
 
     private final PharmacySearchService pharmacySearchService;
+    private final DirectionRepository directionRepository;
+    private final KakaoCategorySearchService kakaoCategorySearchService;
     private static final int MAX_SEARCH_COUNT = 3;
     private static final double RADIUS_KM = 10;
 
+
+    @Transactional
+    public List<Direction> saveAll(List<Direction> directionList) {
+        if (CollectionUtils.isEmpty(directionList)) return Collections.emptyList();
+
+        return directionRepository.saveAll(directionList);
+
+    }
+
+    @Transactional(readOnly = true)
     public List<Direction> buildDirectionList(DocumentDto documentDto) {
 
         if(Objects.isNull(documentDto)) return Collections.emptyList();
@@ -46,7 +61,29 @@ public class DirectionService {
                 .collect(Collectors.toList());
     }
 
+    // pharmacy search by category kakao api
+    public List<Direction> buildDirectionListByCategoryApi(DocumentDto inputDocumentDto) {
+        if(Objects.isNull(inputDocumentDto)) return Collections.emptyList();
 
+        return kakaoCategorySearchService
+                .requestPharmacyCategorySearch(inputDocumentDto.getLatitude(), inputDocumentDto.getLongitude(), RADIUS_KM)
+                .getDocumentDtoList()
+                .stream().map(resultDocumentDto ->
+                        Direction.builder()
+                                .inputAddress(inputDocumentDto.getAddressName())
+                                .inputLatitude(inputDocumentDto.getLatitude())
+                                .inputLongitude(inputDocumentDto.getLongitude())
+                                .targetPharmacyName(resultDocumentDto.getPlaceName())
+                                .targetAddress(resultDocumentDto.getAddressName())
+                                .targetLatitude(resultDocumentDto.getLatitude())
+                                .targetLongitude(resultDocumentDto.getLongitude())
+                                .distance(resultDocumentDto.getDistance() * 0.001) // km 단위
+                                .build())
+                .limit(MAX_SEARCH_COUNT)
+                .collect(Collectors.toList());
+    }
+
+    // Haversine formula
     public double calculateDistance(DocumentDto documentDto, PharmacyDto pharmacyDto) {
         double lat1 = Math.toRadians(documentDto.getLatitude());
         double lon1 = Math.toRadians(documentDto.getLongitude());
@@ -54,7 +91,7 @@ public class DirectionService {
         double lon2 = Math.toRadians(pharmacyDto.getLongitude());
 
         double earthRadius = 6371; //Kilometers
-        return earthRadius * Math.acos(Math.sin(lat1) * Math.sin(lat2) + Math.cos(lat1) * Math.cos(lat2) * Math.cos(lon1 - lon2)); //거리계산 알고리즘
+        return earthRadius * Math.acos(Math.sin(lat1) * Math.sin(lat2) + Math.cos(lat1) * Math.cos(lat2) * Math.cos(lon1 - lon2));
     }
 
 }

--- a/src/main/java/com/example/naviproject/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/example/naviproject/pharmacy/service/PharmacyRecommendationService.java
@@ -1,0 +1,46 @@
+package com.example.naviproject.pharmacy.service;
+
+import com.example.naviproject.api.dto.DocumentDto;
+import com.example.naviproject.api.dto.KakaoApiResponseDto;
+import com.example.naviproject.api.service.KakaoAddressSearchService;
+import com.example.naviproject.direction.entity.Direction;
+import com.example.naviproject.direction.service.DirectionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class PharmacyRecommendationService {
+
+    private final KakaoAddressSearchService kakaoAddressSearchService;
+    private final DirectionService directionService;
+
+    public void recommendPharmacyList(String address) {
+
+        KakaoApiResponseDto kakaoApiResponseDto = kakaoAddressSearchService.requestAddressSearch(address);
+
+        if (Objects.isNull(kakaoApiResponseDto) || CollectionUtils.isEmpty(kakaoApiResponseDto.getDocumentDtoList())) {
+            log.error("[PharmacyRecommendationService recommendPharmacyList fail] Input address: {}", address);
+            return;
+        }
+
+        DocumentDto documentDto = kakaoApiResponseDto.getDocumentDtoList().get(0);
+
+        List<Direction> directionList = directionService.buildDirectionList(documentDto);
+//        List<Direction> directions = directionService.buildDirectionListByCategoryApi(documentDto); 카테고리 검색 서비스
+        directionService.saveAll(directionList);
+
+    }
+
+
+}

--- a/src/test/groovy/com/example/naviproject/api/service/KakaoAddressSearchServiceTest.groovy
+++ b/src/test/groovy/com/example/naviproject/api/service/KakaoAddressSearchServiceTest.groovy
@@ -1,0 +1,35 @@
+package com.example.naviproject.api.service
+
+import com.example.naviproject.AbstractIntegrationContainerBaseTest
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Specification
+
+class KakaoAddressSearchServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    KakaoAddressSearchService kakaoAddressSearchService;
+
+    def "정상적인 주소를 입력했을 경우, 정상적으로 위도 경도로 변환 된다."() {
+
+        given:
+        boolean actualResult = false
+
+        when:
+        def searchResult = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        if(searchResult == null) actualResult = false
+        else actualResult = searchResult.getDocumentDtoList().size() > 0
+
+        where:
+        inputAddress                            | expectedResult
+        "서울 특별시 성북구 종암동"                   | true
+        "서울 성북구 종암동 91"                     | true
+        "서울 대학로"                             | true
+        "서울 성북구 종암동 잘못된 주소"               | false
+        "광진구 구의동 251-45"                     | true
+        "광진구 구의동 251-455555"                 | false
+        ""                                      | false
+    }
+
+}


### PR DESCRIPTION
기존 DB의 약국 데이터에만 의존하여 추천하였지만 카카오 카테고리 검색 API를 적용해 약국 데이터에 국한되지않고 약국을 추천할수있습니다.